### PR TITLE
Remove try catch from CommandHandlerMiddleware

### DIFF
--- a/src/Middleware/CommandHandlerMiddleware.php
+++ b/src/Middleware/CommandHandlerMiddleware.php
@@ -11,12 +11,12 @@ use PhpCmd\CmdBus\CommandHandlerInterface;
 use PhpCmd\CmdBus\CommandHandlerResolverInterface;
 use PhpCmd\CmdBus\CommandInterface;
 use PhpCmd\CmdBus\MiddlewareInterface;
-use Throwable;
 
-class CommandHandlerMiddleware implements MiddlewareInterface
+/** @internal */
+final readonly class CommandHandlerMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly CommandHandlerResolverInterface $resolver
+        private CommandHandlerResolverInterface $resolver
     ) {
     }
 
@@ -27,14 +27,14 @@ class CommandHandlerMiddleware implements MiddlewareInterface
     ): mixed {
         // Resolve the command handler for the given command
         $cmdHandler = $this->resolver->resolve($command);
-        try {
-            // run the command and capture results
-            $result = $cmdHandler->handle($command);
-            // create a new CommandResult with the captured results
-            $command = new CommandResult($command, CommandStatus::Success, $result);
-        } catch (Throwable $th) {
-            $command = new CommandResult($command, CommandStatus::Failure, $th);
-        }
+
+        // create a new CommandResult with the captured results
+        $command = new CommandResult(
+            $command,
+            CommandStatus::Success,
+            $cmdHandler->handle($command)
+        );
+
         return $handler->handle($command);
     }
 }

--- a/test/unit/Middleware/CommandHandlerMiddlewareTest.php
+++ b/test/unit/Middleware/CommandHandlerMiddlewareTest.php
@@ -14,7 +14,6 @@ use PhpCmd\CmdBus\MiddlewareInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 #[CoversClass(CommandHandlerMiddleware::class)]
 final class CommandHandlerMiddlewareTest extends TestCase

--- a/test/unit/Middleware/CommandHandlerMiddlewareTest.php
+++ b/test/unit/Middleware/CommandHandlerMiddlewareTest.php
@@ -86,35 +86,6 @@ final class CommandHandlerMiddlewareTest extends TestCase
         $this->assertEquals('final result', $result);
     }
 
-    public function testProcessWrapsExceptionInFailureCommandResult(): void
-    {
-        $exception = new RuntimeException('Test exception');
-
-        $this->resolver->expects($this->once())
-            ->method('resolve')
-            ->with($this->command)
-            ->willReturn($this->commandHandler);
-
-        $this->commandHandler->expects($this->once())
-            ->method('handle')
-            ->with($this->command)
-            ->willThrowException($exception);
-
-        $this->handler->expects($this->once())
-            ->method('handle')
-            ->with($this->callback(function ($commandResult) use ($exception) {
-                return $commandResult instanceof CommandResult
-                    && $commandResult->getCommand() === $this->command
-                    && $commandResult->getStatus() === CommandStatus::Failure
-                    && $commandResult->getResult() === $exception;
-            }))
-            ->willReturn('error handled');
-
-        $result = $this->middleware->process($this->command, $this->handler);
-
-        $this->assertEquals('error handled', $result);
-    }
-
     public function testProcessCallsResolverWithCorrectCommand(): void
     {
         $this->resolver->expects($this->once())


### PR DESCRIPTION
Allow exceptions to bubble up from CommandHandlerMiddleware.